### PR TITLE
Get parsers working with new data format, even if just ignoring the new fields.

### DIFF
--- a/discogslabelparser.py
+++ b/discogslabelparser.py
@@ -25,6 +25,7 @@ labelCounter = 0
 
 class LabelHandler(xml.sax.handler.ContentHandler):
 	inElement = {
+				'id': False,
 				'label': False,
 				'labels': False,
 				'data_quality': False,

--- a/discogsmasterparser.py
+++ b/discogsmasterparser.py
@@ -26,6 +26,9 @@ masterCounter = 0
 class MasterHandler(xml.sax.handler.ContentHandler):
 	def __init__(self, exporter, stop_after=0, ignore_missing_tags=False):
 		self.knownTags = (
+							'id',
+							'videos',
+							'video',
 							'anv',
 							'artist',
 							'artists',

--- a/discogsreleaseparser.py
+++ b/discogsreleaseparser.py
@@ -26,6 +26,17 @@ releaseCounter = 0
 class ReleaseHandler(xml.sax.handler.ContentHandler):
 	def __init__(self, exporter, stop_after=0, ignore_missing_tags=False):
 		self.knownTags = (
+							'id',
+							'identifiers',
+							'identifier',
+							'videos',
+							'video',
+							'companies',
+							'company',
+							'catno',
+							'entity_type',
+							'entity_type_name',
+							'resource_url',
 							'anv',
 							'artist',
 							'artists',


### PR DESCRIPTION
This allows the new fields through but does nothing with them.

At least the code as presented will run and include the data included in the old schema. The path forward from here is to do something meaningful with the data once parsed.
