### PR TITLE
Release identifiers, video and company in postgres. Batch insert

### DIFF
--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,17 +1,5 @@
 SET client_encoding = 'UTF8';
-SET standard_conforming_strings = off;
-SET check_function_bodies = false;
-SET client_min_messages = warning;
-SET escape_string_warning = off;
 
-SET search_path = discogs;
-
-SET default_tablespace = '';
-
-SET default_with_oids = false;
-
-SET synchronous_commit=off;
- 
 CREATE UNLOGGED TABLE artist (
     id 				integer NOT NULL,
     name 			text NOT NULL,
@@ -200,6 +188,32 @@ CREATE UNLOGGED TABLE masters_images (
     width 			integer,
     image_uri text
 );
+
+CREATE UNLOGGED TABLE identifier (
+    release_id integer,
+    description 		text,
+    type 		text,
+    value 		text
+);
+
+CREATE UNLOGGED TABLE video (
+    release_id integer,
+    duration text,
+    embed text,
+    src text,
+    title text,
+    description text
+);
+
+CREATE UNLOGGED TABLE release_company (
+    release_id integer,
+    company_id integer,
+    name text,
+    catno text,
+    entity_type integer,
+    entity_type_name text
+);
+
 
 REVOKE ALL ON SCHEMA public FROM PUBLIC;
 REVOKE ALL ON SCHEMA public FROM postgres;

--- a/discogsparser.py
+++ b/discogsparser.py
@@ -229,13 +229,12 @@ that --params is used, e.g.:
 
 	exporter = make_exporter(options)
 	parser = xml.sax.make_parser()
-	try:
-		parseArtists(parser, exporter)
-		parseLabels(parser, exporter)
-		parseReleases(parser, exporter)
-		parseMasters(parser, exporter)
-	finally:
-		exporter.finish(completely_done = True)
+	parseArtists(parser, exporter)
+	parseLabels(parser, exporter)
+	parseReleases(parser, exporter)
+	parseMasters(parser, exporter)
+
+	exporter.finish(completely_done = True)
 
 if __name__ == "__main__":
 	main(sys.argv[1:])

--- a/discogsreleaseparser.py
+++ b/discogsreleaseparser.py
@@ -50,7 +50,6 @@ class ReleaseHandler(xml.sax.handler.ContentHandler):
 							'formats',
 							'genre',
 							'genres',
-							#'indentifiers', 'identifier',
 							'image',
 							'images',
 							'join',
@@ -72,7 +71,7 @@ class ReleaseHandler(xml.sax.handler.ContentHandler):
 							'tracklist',
 							'tracks',
 							'url',
-							'urls',
+							'urls'
 							)
 		self.release = None
 		self.buffer = ''
@@ -128,6 +127,25 @@ class ReleaseHandler(xml.sax.handler.ContentHandler):
 		elif name == 'identifier' and attrs['type'] == 'Barcode':
 			self.release.barcode = attrs['value']
 
+		elif name == 'company':
+			comp = model.Company()
+			self.release.companies.append(comp);			
+
+		elif name == 'video':
+			vid = model.Video()
+			vid.duration = attrs['duration']
+			vid.embed = attrs['embed']
+			vid.src = attrs['src']
+			self.release.videos.append(vid);			
+			
+		## not in the elif, will lose the barcode
+		if name == 'identifier':
+			ident = model.Identifier()
+			if 'description' in attrs:
+				ident.description = attrs['description']
+			ident.type = attrs['type']
+			ident.value = attrs['value']
+			self.release.identifiers.append(ident)
 
 	def characters(self, data):
 		self.buffer += data
@@ -314,6 +332,23 @@ class ReleaseHandler(xml.sax.handler.ContentHandler):
 					if self.ignore_missing_tags and len(self.unknown_tags) > 0:
 						print 'Encountered some unknown Release tags: %s' % (self.unknown_tags)
 					raise model.ParserStopError(releaseCounter)
+
+		if name == 'id' and 'company' in self.stack:
+			self.release.companies[-1].id = self.buffer
+		if name == 'name' and 'company' in self.stack:
+			self.release.companies[-1].name = self.buffer
+		if name == 'catno' and 'company' in self.stack:
+			self.release.companies[-1].catno = self.buffer
+		if name == 'entity_type' and 'company' in self.stack:
+			self.release.companies[-1].entity_type = self.buffer
+		if name == 'entity_type_name' and 'company' in self.stack:
+			self.release.companies[-1].entity_type_name = self.buffer
+
+		if name == 'title' and 'video' in self.stack:
+			self.release.videos[-1].title = self.buffer
+		if name == 'description' and 'video' in self.stack:
+			self.release.videos[-1].description = self.buffer
+
 
 		if self.stack[-1] == name:
 			self.stack.pop()

--- a/model.py
+++ b/model.py
@@ -32,7 +32,9 @@ class Release:
      self.artistJoins = [] 
      self.tracklist = [] 
      self.extraartists = []
-     #self.indentifiers = [] # 
+     self.identifiers = [] 
+     self.videos  = []
+     self.companies = [] 
 
 class Master:
    def __init__(self):
@@ -104,6 +106,30 @@ class Track:
     self.title = ''
     self.duration = ''
     self.position = ''
+    
+    
+class Identifier:
+  def __init__(self):
+    self.description = ''
+    self.type = ''
+    self.value = ''
+
+class Video:
+  def __init__(self):
+    self.duration = ''
+    self.embed = ''
+    self.src = ''
+    self.title = ''
+    self.description = ''
+
+class Company:
+  def __init__(self):
+    self.id = ''
+    self.name = ''
+    self.catno = ''
+    self.entity_type = ''
+    self.entity_type_name = ''
+   
 
 class ImageInfo:
   def __init__(self):


### PR DESCRIPTION
@philipmat 

Some issues:
- number of tracks in the DB is 53,434,173 while the number of XML
  <track> elements is 53,832,994. Would be interesting to figure out where
  these tracks go. Hopefully it is not because of my changes :)
- it would be nice to normalize the data (I write it more or less in the
  way we get it from the XML) but this is not always possible; for
  company, multiple companies have the ID of 0. Also, it seems that
  different spellings apply for the same ID.
- batch import did not change so much the performance. It still took me
  about 10 hours, but considering the added SQL. Probably dumping the data
  in some file and perform bulk table loads is the long term solution.
- I run the code against Postgres 9.3, I removed some "set" statement
  from the sql script, so that they run on my configuration
- I removed a try/finally because in case of an exception in the try
  block, the finally got executed, but finally was throwing a new
  exception. This way it is simpler to debug.
