### PR TITLE
fix urls of discogs data dumps

### DIFF
--- a/get_latest_dumps.sh
+++ b/get_latest_dumps.sh
@@ -16,6 +16,6 @@ for f in `wget -c --user-agent="$USER_AGENT" --header="$ACCEPT" -qO- $D_URL_LIST
 	echo $D_URL_DIR$f >> $D_TMP
 done
 
-wget -c --user-agent="$USER_AGENT" --header="$ACCEPT" --no-clobber --input-file=$D_TMP $TEST --append-output=$D_TMP.log 
+wget -c --user-agent="$USER_AGENT" --header="$ACCEPT" --no-clobber --input-file=$D_TMP $TEST -q --show-progress
 
 


### PR DESCRIPTION
The URLs of the discogs data dumps changed now they are stored on amazon s3.
This fixes issue #68 and the getlatestdumps.sh script.