### PR TITLE
Code cleanup suggestions

### DIFF
--- a/discogsparser.py
+++ b/discogsparser.py
@@ -56,125 +56,53 @@ def first_file_match(file_pattern):
 	return None
 
 
-def parseArtists(parser, exporter):
+def parseEntities(parser, exporter, entities, handler_class):
 	global options
-	artist_file = None
-	in_file = first_file_match('_artists.xml')
+	entity_file = None
+	in_file = first_file_match('_%s.xml' % entities)
 	if options.date is not None:
-		artist_file = "discogs_%s_artists.xml" % options.date
+		entity_file = "discogs_%s_%s.xml" % (options.date, entities)
 	elif in_file is not None:
-		artist_file = in_file
+		entity_file = in_file
 
-	if artist_file is None:
-		# print("No artist file specified.")
+	if entity_file is None:
+		# print("No %s file specified." % entities)
 		return
-	elif not path.exists(artist_file):
-		# print("File %s doesn't exist:" % artist_file)
+	elif not path.exists(entity_file):
+		# print("File %s doesn't exist:" % entity_file)
 		return
 
-	from discogsartistparser import ArtistHandler
-	artistHandler = ArtistHandler(exporter, stop_after=options.n, ignore_missing_tags=options.ignore_unknown_tags)
-	parser.setContentHandler(artistHandler)
+	entityHandler = handler_class(exporter, stop_after=options.n, ignore_missing_tags=options.ignore_unknown_tags)
+	parser.setContentHandler(entityHandler)
 	try:
-		if artist_file.endswith(".gz"):
-			with gzip.open(artist_file) as f:
-				parser.parse(f)
+		if entity_file.endswith(".gz"):
+			_open = gzip.open
 		else:
-			parser.parse(artist_file)
+			_open = open
+		with _open(entity_file) as f:
+			parser.parse(f)
 	except ParserStopError as pse:
-		print("Parsed %d artists then stopped as requested." % pse.records_parsed)
-# 	except model.ParserStopError as pse22:
-# 		print("Parsed %d artists then stopped as requested." % pse.records_parsed)
-# 	except Exception as ex:
-# 		print("Raised unknown error")
-# 		print(type(ex))
+		print("Parsed %d %s then stopped as requested." % (pse.records_parsed, entities))
+
+
+def parseArtists(parser, exporter):
+	from discogsartistparser import ArtistHandler
+	parseEntities(parser, exporter, 'artists', ArtistHandler)
 
 
 def parseLabels(parser, exporter):
-	global options
-	label_file = None
-	in_file = first_file_match('_labels.xml')
-	if options.date is not None:
-		label_file = "discogs_%s_labels.xml" % options.date
-	elif in_file is not None:
-		label_file = in_file
-
-	if label_file is None:
-		# print("No label file specified.")
-		return
-	elif not path.exists(label_file):
-		# print("File %s doesn't exist:" % label_file)
-		return
-
 	from discogslabelparser import LabelHandler
-	labelHandler = LabelHandler(exporter, stop_after=options.n, ignore_missing_tags=options.ignore_unknown_tags)
-	parser.setContentHandler(labelHandler)
-	try:
-		if label_file.endswith(".gz"):
-			with gzip.open(label_file) as f:
-				parser.parse(f)
-		else:
-			parser.parse(label_file)
-	except ParserStopError as pse:
-		print("Parsed %d labels then stopped as requested." % pse.records_parsed)
+	parseEntities(parser, exporter, 'labels', LabelHandler)
 
 
 def parseReleases(parser, exporter):
-	global options
-	release_file = None
-	in_file = first_file_match('_releases.xml')
-	if options.date is not None:
-		release_file = "discogs_%s_releases.xml" % options.date
-	elif in_file is not None:
-		release_file = in_file
-
-	if release_file is None:
-		# print("No release file specified.")
-		return
-	elif not path.exists(release_file):
-		# print("File %s doesn't exist:" % release_file)
-		return
-
 	from discogsreleaseparser import ReleaseHandler
-	releaseHandler = ReleaseHandler(exporter, stop_after=options.n, ignore_missing_tags=options.ignore_unknown_tags)
-	parser.setContentHandler(releaseHandler)
-	try:
-		if release_file.endswith(".gz"):
-			with gzip.open(release_file) as f:
-				parser.parse(f)
-		else:
-			parser.parse(release_file)
-	except ParserStopError as pse:
-		print("Parsed %d releases then stopped as requested." % pse.records_parsed)
+	parseEntities(parser, exporter, 'releases', ReleaseHandler)
 
 
 def parseMasters(parser, exporter):
-	global options
-	master_file = None
-	in_file = first_file_match('_masters.xml')
-	if options.date is not None:
-		master_file = "discogs_%s_masters.xml" % options.date
-	elif in_file is not None:
-		master_file = in_file
-
-	if master_file is None:
-		# print("No masters file specified.")
-		return
-	elif not path.exists(master_file):
-		# print("File %s doesn't exist:" % master_file)
-		return
-
 	from discogsmasterparser import MasterHandler
-	masterHandler = MasterHandler(exporter, stop_after=options.n, ignore_missing_tags=options.ignore_unknown_tags)
-	parser.setContentHandler(masterHandler)
-	try:
-		if master_file.endswith(".gz"):
-			with gzip.open(master_file) as f:
-				parser.parse(f)
-		else:
-			parser.parse(master_file)
-	except ParserStopError as pse:
-		print("Parsed %d masters then stopped as requested." % pse.records_parsed)
+	parseEntities(parser, exporter, 'masters', MasterHandler)
 
 
 def select_exporter(options):

--- a/discogsparser.py
+++ b/discogsparser.py
@@ -152,7 +152,6 @@ that --params is used, e.g.:
 	opt_parser.add_argument('file', nargs='*', help='Specific file(s) to import. Default is to parse artists, labels, releases matching -d')
 	global options
 	options = opt_parser.parse_args(argv)
-	print(options)
 
 	if options.date is None and len(options.file) == 0:
 		opt_parser.print_help()

--- a/postgresexporter.py
+++ b/postgresexporter.py
@@ -96,7 +96,7 @@ class PostgresExporter(object):
 			columns += ",sublabels"
 
 		escapeStrings = ''
-		for counter in xrange(1, len(columns.split(","))):
+		for counter in range(1, len(columns.split(","))):
 			escapeStrings = escapeStrings + ",%s"
 		escapeStrings = '(%s' + escapeStrings + ')'
 		# print(values)
@@ -141,7 +141,7 @@ class PostgresExporter(object):
 			columns += ",members"
 
 		escapeStrings = ''
-		for counter in xrange(1, len(columns.split(","))):
+		for counter in range(1, len(columns.split(","))):
 			escapeStrings = escapeStrings + ",%s"
 		escapeStrings = '(%s' + escapeStrings + ')'
 		# print(values)
@@ -189,7 +189,7 @@ class PostgresExporter(object):
 
 		# INSERT INTO DATABASE
 		escapeStrings = ''
-		for counter in xrange(1, len(columns.split(","))):
+		for counter in range(1, len(columns.split(","))):
 			escapeStrings = escapeStrings + ",%s"
 		escapeStrings = '(%s' + escapeStrings + ')'
 		# print(values)
@@ -277,7 +277,7 @@ class PostgresExporter(object):
 
 		# INSERT INTO DATABASE
 		escapeStrings = ''
-		for counter in xrange(1, len(columns.split(","))):
+		for counter in range(1, len(columns.split(","))):
 			escapeStrings = escapeStrings + ",%s"
 		escapeStrings = '(%s' + escapeStrings + ')'
 		# print(values)
@@ -328,9 +328,10 @@ class PostgresExporter(object):
 
 class PostgresConsoleDumper(PostgresExporter):
 
-	def __init__(self, connection_string):
-		super(PostgresConsoleDumper, self).__init__(connection_string)
-		self.q = lambda x: "'%s'" % x.replace("'", "\\'")
+	def __init__(self, connection_string, data_quality=None):
+		super(PostgresConsoleDumper, self).__init__(connection_string, data_quality)
+		self.q = lambda x: "'%s'" % str(x).replace("'", "\\'") if x else "''"
+		self.min_data_quality = data_quality
 
 	def connect(self, connection_string):
 		pass
@@ -350,5 +351,5 @@ class PostgresConsoleDumper(PostgresExporter):
 		qparams = self.qs(params)
 		print(query % tuple(qparams))
 
-	def finish(self):
+	def finish(self, completely_done=False):
 		pass

--- a/postgresexporter.py
+++ b/postgresexporter.py
@@ -21,6 +21,7 @@ import sys
 
 from psycopg2.extensions import adapt, register_adapter
 
+
 def untuple(what):
 	if type(what) is tuple:
 		return list(what)
@@ -74,6 +75,7 @@ class PostgresExporter(object):
 			self.cur.close()
 
 	_query_cache = {}
+
 	def buildEscapedQuery(self, table, columns):
 		qkey = (table, tuple(columns))
 		q = self._query_cache.get(qkey)
@@ -119,8 +121,10 @@ class PostgresExporter(object):
 
 		for img in label.images:
 			values = (img.imageType, img.height, img.width, label.id)
-			self.runQuery('labels_images',
-				['type', 'height', 'width', 'label_id'], values)
+			self.runQuery(
+				'labels_images',
+				['type', 'height', 'width', 'label_id'],
+				values)
 
 	def storeArtist(self, artist):
 		if not self.good_quality(artist):
@@ -154,8 +158,10 @@ class PostgresExporter(object):
 
 		for img in artist.images:
 			values = (img.imageType, img.height, img.width, artist.id)
-			self.runQuery('artists_images',
-				['type', 'height', 'width', 'artist_id'], values)
+			self.runQuery(
+				'artists_images',
+				['type', 'height', 'width', 'artist_id'],
+				values)
 
 	def storeRelease(self, release):
 		if not self.good_quality(release):
@@ -166,7 +172,7 @@ class PostgresExporter(object):
 				('id', 'id'),
 				('title', 'title'),
 				('status', 'status'),
-				('barcode', 'barcode'),]:
+				('barcode', 'barcode')]:
 			values.append(getattr(release, attr))
 			columns.append(column)
 
@@ -193,8 +199,10 @@ class PostgresExporter(object):
 
 		for img in release.images:
 			values = (img.imageType, img.height, img.width, release.id)
-			self.runQuery('releases_images',
-				['type', 'height', 'width', 'release_id'], values)
+			self.runQuery(
+				'releases_images',
+				['type', 'height', 'width', 'release_id'],
+				values)
 
 		for fmt_order, fmt in enumerate(release.formats, start=1):
 			if len(release.formats) != 0:
@@ -205,39 +213,47 @@ class PostgresExporter(object):
 					except PostgresExporter.ExecuteError as e:
 						print("%s" % (e.args))
 				values = (release.id, fmt_order, fmt.name, fmt.qty, fmt.descriptions)
-				self.runQuery('releases_formats',
-					['release_id', 'position', 'format_name', 'qty', 'descriptions'], values)
+				self.runQuery(
+					'releases_formats',
+					['release_id', 'position', 'format_name', 'qty', 'descriptions'],
+					values)
 
 		for lbl in release.labels:
-			self.runQuery('releases_labels',
+			self.runQuery(
+				'releases_labels',
 				['release_id', 'label', 'catno'],
 				(release.id, lbl.name, lbl.catno))
 
 		for aj_pos, aj in enumerate(release.artistJoins, start=1):
-			self.runQuery('releases_artists',
+			self.runQuery(
+				'releases_artists',
 				['release_id', 'position', 'artist_id', 'artist_name', 'join_relation', 'anv'],
 				(release.id, aj_pos, aj.artist_id, aj.artist_name, aj.join_relation, aj.anv))
 
 		for extr in release.extraartists:
 			for role in extr.roles:
-				self.runQuery('releases_extraartists',
-					['release_id', 'artist_id',     'artist_name',    'role', 'anv'],
+				self.runQuery(
+					'releases_extraartists',
+					['release_id', 'artist_id', 'artist_name', 'role', 'anv'],
 					(release.id, extr.artist_id, extr.artist_name, role, extr.anv))
 
 		for trackno, trk in enumerate(release.tracklist, start=1):
 			trackid = str(uuid.uuid4())
-			self.runQuery('track',
+			self.runQuery(
+				'track',
 				['release_id', 'title', 'duration', 'position', 'track_id', 'trackno'],
 				(release.id, trk.title, trk.duration, trk.position, trackid, trackno))
 
 			for track_artist_order, aj in enumerate(trk.artistJoins, start=1):
-				self.runQuery('tracks_artists',
+				self.runQuery(
+					'tracks_artists',
 					['track_id', 'position', 'artist_name', 'artist_id', 'join_relation', 'anv'],
 					(trackid, track_artist_order, aj.artist_name, aj.artist_id, aj.join_relation, aj.anv))
 
 			for extr in trk.extraartists:
 				for role in extr.roles:
-					self.runQuery('tracks_extraartists',
+					self.runQuery(
+						'tracks_extraartists',
 						['track_id', 'artist_id', 'artist_name', 'role', 'anv'],
 						(trackid, extr.artist_id, extr.artist_name, role, extr.anv))
 
@@ -261,7 +277,7 @@ class PostgresExporter(object):
 		for attr, column in [
 				('notes', 'notes'),
 				('genres', 'genres'),
-				('styles', 'styles'),]:
+				('styles', 'styles')]:
 			value = getattr(master, attr)
 			if len(value) != 0:
 				values.append(value)
@@ -275,13 +291,16 @@ class PostgresExporter(object):
 
 		for img in master.images:
 			values = (img.imageType, img.height, img.width, master.id)
-			self.runQuery('masters_images',
+			self.runQuery(
+				'masters_images',
 				['type', 'height', 'width', 'master_id'], values)
 
 		if len(master.artists) > 1:
 			for artist in master.artists:
-				self.runQuery('masters_artists',
-					['master_id', 'artist_name'], (master.id, artist))
+				self.runQuery(
+					'masters_artists',
+					['master_id', 'artist_name'],
+					(master.id, artist))
 			for aj in master.artistJoins:
 				artistIdx = master.artists.index(aj.artist1) + 1
 				# The last join relation is not between artists but instead
@@ -290,18 +309,22 @@ class PostgresExporter(object):
 					values = (master.id, aj.join_relation, '', '')  # join relation is between all artists and the album
 				else:
 					values = (master.id, aj.join_relation, aj.artist1, master.artists[artistIdx])
-				self.runQuery('masters_artists_joins',
-					['master_id', 'join_relation', 'artist1', 'artist2'], values)
+				self.runQuery(
+					'masters_artists_joins',
+					['master_id', 'join_relation', 'artist1', 'artist2'],
+					values)
 		else:
 
-			self.runQuery('masters_artists',
+			self.runQuery(
+				'masters_artists',
 				['master_id', 'artist_name'],
 				# use anv if no artist name
 				(master.id, master.artists[0] if master.artists else master.anv))
 
 		for extr in master.extraartists:
 			# decide whether to insert flattened composite roles or take the first one from the tuple
-			self.runQuery('masters_extraartists',
+			self.runQuery(
+				'masters_extraartists',
 				['master_id', 'artist_name', 'roles'],
 				# (master.id, extr.name, flatten(extr.roles)))
 				(master.id, extr.name, map(lambda x: x[0] if type(x) is tuple else x, extr.roles)))
@@ -317,8 +340,9 @@ class SQL_LIST(object):
 		self._conn = conn
 
 	def getquoted(self):
-		return b"'{" + b', '.join(json.dumps(o, ensure_ascii=False).encode('utf-8')
-			                      for o in self._seq) + b"}'"
+		return (b"'{" + b', '.join(
+				json.dumps(o, ensure_ascii=False).encode('utf-8')
+				for o in self._seq) + b"}'")
 
 	def __str__(self):
 		return str(self.getquoted())

--- a/postgresexporter.py
+++ b/postgresexporter.py
@@ -353,9 +353,15 @@ class PostgresConsoleDumper(PostgresExporter):
 	def __init__(self, connection_string, data_quality=None):
 		super(PostgresConsoleDumper, self).__init__(connection_string, data_quality)
 		register_adapter(list, SQL_LIST)
+		try:
+			self.stdoutw = sys.stdout.buffer.write
+		except AttributeError:
+			self.stdoutw = sys.stdout.write
 
 	def execute(self, query, params):
-		print(self.cur.mogrify(query, params).decode())
+		sqlbytes = self.cur.mogrify(query, params)
+		self.stdoutw(sqlbytes)
+		self.stdoutw(b'\n')
 
 	def finish(self, completely_done=False):
 		from psycopg2._psycopg import List


### PR DESCRIPTION
Hi all,

while looking at integrating some speed improvements to the current code base, I started refactoring some of the parser and postgresql exporter code:

- `discogsparser.parse{Artists,Labels,Masters,Releases}` all look very similar and a new `parseEntities` is introduced
- `postgresexporter.PostgresExporter` now uses a common `runQuery/buildEscapedQuery` combo to ease building SQL queries with placeholders. Also this could allow overriding these to export as CSV to later import

I can leave out the changes to `PostgresConsoleDumper`: the main change is that the cursor from `PostgresExporter` is kept to use `mogrify`. I tested the output of this new `PostgresConsoleDumper` to create .sql files to feed to  `psql` and it seems to work fine.