### PR TITLE
Allows specifying dump files individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,23 +62,41 @@ $ sha256sum -c discogs_*_CHECKSUM.txt
 
 Run `run.py` to convert the dump files to csv.
 
+There are two run modes:
+
+1. You can point it to a directory where the discogs dump files are
+   and use one or multiple `--export` options to indicate which files to process:
+
 ```sh
 # ensure the virtual environment is active
 (.discogsenv) $ python3 run.py \
   --bz2 \ # compresses resulting csv files
   --apicounts \ # provides more accurate progress counts
   --export artist --export label --export master --export release \
+  --output csv-dir    # folder where to output the csv files
   dump-dir \ # folder where the data dumps are
-  csv-dir    # folder where to output the csv files
+```
+
+2. You can specify the individual files instead:
+
+```sh
+# ensure the virtual environment is active
+(.discogsenv) $ python3 run.py \
+  --bz2 \ # compresses resulting csv files
+  --apicounts \ # provides more accurate progress counts
+  --output csv-dir    # folder where to output the csv files
+  path/to/discogs_20200806_artist.xml.gz path/to/discogs_20200806_labels.xml.gz
 ```
 
 `run.py` takes the following arguments:
 
 - `--export`: the types of dump files to export: "artist", "label", "master", "release.  
   It matches the names of the dump files, e.g. "discogs_20200806_*artist*s.xml.gz"
+  Not needed if the individual files are specified.
 - `--bz2`: Compresses output csv files using bz2 compression library.
 - `--limit=<lines>`: Limits export to some number of entities
 - `--apicounts`: Makes progress report more accurate by getting total amounts from Discogs API.
+- `--output` : the folder where to store the csv files; default it current directory
 
 The exporter provides progress information in real time:
 

--- a/discogsxml2db/exporter.py
+++ b/discogsxml2db/exporter.py
@@ -314,7 +314,7 @@ def main(arguments):
         except Exception:
             pass
 
-    if arguments['INPUT_DIR']:
+    if arguments["INPUT_DIR"] and os.path.isdir(arguments["INPUT_DIR"]):
         # use --export to select the entities
         in_base = arguments['INPUT_DIR']
         for entity in arguments['--export']:
@@ -328,8 +328,13 @@ def main(arguments):
                 max_hint=min(expected_count, limit or expected_count),
                 dry_run=dry_run)
             exporter.export()
-    elif arguments["<INPUT_FILE>"]:
-        for in_file in arguments["<INPUT_FILE>"]:
+    elif arguments["<INPUT_FILE>"] or os.path.isfile(arguments["INPUT_DIR"]):
+        files = []
+        if arguments["<INPUT_FILE>"]:
+            files = arguments["<INPUT_FILE>"]
+        else:
+            files = [ arguments["INPUT_DIR"] ]
+        for in_file in files:
             for entity in _exporters:
                 # discogs files are named discogs_{date}_{entity}s.xml
                 if f"_{entity}" in in_file:

--- a/discogsxml2db/exporter.py
+++ b/discogsxml2db/exporter.py
@@ -333,7 +333,7 @@ def main(arguments):
         if arguments["<INPUT_FILE>"]:
             files = arguments["<INPUT_FILE>"]
         else:
-            files = [ arguments["INPUT_DIR"] ]
+            files = [arguments["INPUT_DIR"]]
         for in_file in files:
             for entity in _exporters:
                 # discogs files are named discogs_{date}_{entity}s.xml

--- a/run.py
+++ b/run.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Usage:
-  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] INPUT [OUTPUT] [--export=<entity>]...
+  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<output>] INPUT_DIR [--export=<entity>]...
+  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<output>] <INPUT_FILE> <INPUT_FILE>...
 
 Options:
   --bz2                 Compress output files using bz2 compression library.
   --limit=<lines>       Limit export to some number of entities
-  --export=<entity>     Limit export to some entities (repeatable)
+  --export=<entity>     Limit export to some entities (repeatable).
+                        Entity is one of: artist, label, master, release.
   --debug               Turn on debugging prints
   --apicounts           Check entities counts with Discogs API
-  --dry-run             Do not write
+  --dry-run             Do not write csv files.
 
 """
 import sys
@@ -20,4 +22,6 @@ from discogsxml2db.exporter import main
 
 if __name__ == '__main__':
     arguments = docopt(__doc__, version='Discogs-to-SQL exporter')
+    if arguments["--debug"]:
+        print(arguments)
     sys.exit(main(arguments))

--- a/run.py
+++ b/run.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Usage:
-  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<output>] INPUT_DIR [--export=<entity>]...
-  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<output>] <INPUT_FILE> <INPUT_FILE>...
+  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<dir>] <INPUT_FILE> <INPUT_FILE>...
+  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<dir>] INPUT_DIR [--export=<entity>]...
 
 Options:
   --bz2                 Compress output files using bz2 compression library.
@@ -12,7 +12,7 @@ Options:
   --debug               Turn on debugging prints
   --apicounts           Check entities counts with Discogs API
   --dry-run             Do not write csv files.
-  --output              Where to write the csv files. Defaults to current dir.
+  --output=<dir> Where to write the csv files. Defaults to current dir.
 
 """
 import sys

--- a/run.py
+++ b/run.py
@@ -6,12 +6,13 @@
 
 Options:
   --bz2                 Compress output files using bz2 compression library.
-  --limit=<lines>       Limit export to some number of entities
+  --limit=<lines>       Limit export to some number of entities (all otherwise)
   --export=<entity>     Limit export to some entities (repeatable).
                         Entity is one of: artist, label, master, release.
   --debug               Turn on debugging prints
   --apicounts           Check entities counts with Discogs API
   --dry-run             Do not write csv files.
+  --output              Where to write the csv files. Defaults to current dir.
 
 """
 import sys

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -76,8 +76,8 @@ class TestExtraction:
         # - export=label
 
         arguments = {
-            "INPUT": self._samples_folder,
-            "OUTPUT": tmp_path,
+            "INPUT_DIR": self._samples_folder,
+            "--output": tmp_path,
             "--export": [entity],
             "--limit": None,
             "--bz2": False,


### PR DESCRIPTION
* Fixes #112
* Gains explicit `--output` argument
* can specify either input directory or multiple input files

```sh
$ python run.py --help
Usage:
  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<dir>] <INPUT_FILE> <INPUT_FILE>...
  run.py [--bz2] [--dry-run] [--limit=<lines>] [--debug] [--apicounts] [--output=<dir>] INPUT_DIR [--export=<entity>]...

Options:
  --bz2                 Compress output files using bz2 compression library.
  --limit=<lines>       Limit export to some number of entities (all otherwise)
  --export=<entity>     Limit export to some entities (repeatable).
                        Entity is one of: artist, label, master, release.
  --debug               Turn on debugging prints
  --apicounts           Check entities counts with Discogs API
  --dry-run             Do not write csv files.
  --output=<dir> Where to write the csv files. Defaults to current dir.
```
