### PR TITLE
Remove bashisms from get_latest_dumps.sh

### DIFF
--- a/get_latest_dumps.sh
+++ b/get_latest_dumps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #set -xv
 
 USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22"
@@ -9,7 +9,7 @@ D_TMP=/tmp/discogs.urls
 D_PATTERN="discogs_[0-9]{8}_(artists|labels|masters|releases).xml.gz"
 
 TEST=""
-[[ "$1" == '--test' ]] && TEST='--spider -S'
+[ "$1" = '--test' ] && TEST='--spider -S'
 
 echo "" > $D_TMP
 

--- a/get_latest_dumps.sh
+++ b/get_latest_dumps.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 #set -xv
 
 USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22"


### PR DESCRIPTION
This script is not that complicated and doesn’t use a lot of the features of bash, so in case people want to run this using dash (for lower overhead) or any other POSIX compliant shell, changing the bashisms in this script allow them to do just this.