### PR TITLE
add foreign key sql file

### DIFF
--- a/mysql/AssignForeignKeys.sql
+++ b/mysql/AssignForeignKeys.sql
@@ -1,0 +1,42 @@
+-- Warning: Foreign keys take a long time to create on mysql!
+-- This file will take quite a while. Grab some coffee.
+
+-- artist_id foreign keys
+ALTER TABLE artist_alias ADD CONSTRAINT artist_alias__artist_fk FOREIGN KEY (artist_id) REFERENCES `artist` (id);
+ALTER TABLE artist_image ADD CONSTRAINT artist_image__artist_fk FOREIGN KEY (artist_id) REFERENCES `artist` (id);
+ALTER TABLE artist_namevariation ADD CONSTRAINT artist_namevariation__artist_fk FOREIGN KEY (artist_id) REFERENCES `artist` (id);
+ALTER TABLE artist_url ADD CONSTRAINT artist_url__artist_fk FOREIGN KEY (artist_id) REFERENCES `artist` (id);
+ALTER TABLE group_member ADD CONSTRAINT group_member__artist_fk FOREIGN KEY (member_artist_id) REFERENCES `artist` (id);
+ALTER TABLE release_artist ADD CONSTRAINT release_artist_artist_fk FOREIGN KEY (artist_id) REFERENCES `artist` (id);
+ALTER TABLE master_artist ADD CONSTRAINT master_artist_artist_fk FOREIGN KEY (artist_id) REFERENCES `artist` (id);
+ALTER TABLE release_track_artist ADD CONSTRAINT release_track_artist__artist_fk FOREIGN KEY (artist_id) REFERENCES `artist` (id);
+
+-- label_id foreign keys
+ALTER TABLE label_image ADD CONSTRAINT label_image__label_fk FOREIGN KEY (label_id) REFERENCES `label` (id);
+ALTER TABLE label_url ADD CONSTRAINT label_url__label_fk FOREIGN KEY (label_id) REFERENCES `label` (id);
+ALTER TABLE release_label ADD CONSTRAINT release_label__label_fk FOREIGN KEY (label_id) REFERENCES `label` (id);
+
+-- master_id foreign keys
+ALTER TABLE `release` ADD CONSTRAINT release__master_fk FOREIGN KEY (master_id) REFERENCES `master` (id);
+ALTER TABLE master_artist ADD CONSTRAINT master_artist__master_fk FOREIGN KEY (master_id) REFERENCES `master` (id);
+ALTER TABLE master_genre ADD CONSTRAINT master_genre__master_fk FOREIGN KEY (master_id) REFERENCES `master` (id);
+ALTER TABLE master_image ADD CONSTRAINT master_image__master_fk FOREIGN KEY (master_id) REFERENCES `master` (id);
+ALTER TABLE master_style ADD CONSTRAINT master_style__master_fk FOREIGN KEY (master_id) REFERENCES `master` (id);
+ALTER TABLE master_video ADD CONSTRAINT master_video__master_fk FOREIGN KEY (master_id) REFERENCES `master` (id);
+
+-- release_id foreign keys
+ALTER TABLE `master` ADD CONSTRAINT master__main_release_fk FOREIGN KEY (main_release) REFERENCES `release` (id);
+ALTER TABLE release_artist ADD CONSTRAINT release_artist__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_company ADD CONSTRAINT release_company__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_format ADD CONSTRAINT release_format__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_genre ADD CONSTRAINT release_genre__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_identifier ADD CONSTRAINT release_identifier__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_image ADD CONSTRAINT release_image__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_label ADD CONSTRAINT release_label__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_style ADD CONSTRAINT release_style__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_track ADD CONSTRAINT release_track__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_track_artist ADD CONSTRAINT release_track_artist__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+ALTER TABLE release_video ADD CONSTRAINT release_video__release_fk FOREIGN KEY (release_id) REFERENCES `release` (id);
+
+-- track_id foreign keys
+# ALTER TABLE release_track_artist ADD CONSTRAINT release_track_artist__track_fk FOREIGN KEY (track_id) REFERENCES `release_track_artist` (id);

--- a/mysql/DropForeignKeys.sql
+++ b/mysql/DropForeignKeys.sql
@@ -1,0 +1,42 @@
+-- Warning: Foreign keys take a long time to create on mysql!
+-- This file will take quite a while. Grab some coffee.
+
+-- artist_id foreign keys
+ALTER TABLE artist_alias DROP FOREIGN KEY artist_alias__artist_fk;
+ALTER TABLE artist_image DROP FOREIGN KEY artist_image__artist_fk;
+ALTER TABLE artist_namevariation DROP FOREIGN KEY artist_namevariation__artist_fk;
+ALTER TABLE artist_url DROP FOREIGN KEY artist_url__artist_fk;
+ALTER TABLE group_member DROP FOREIGN KEY group_member__artist_fk;
+ALTER TABLE release_artist DROP FOREIGN KEY release_artist_artist_fk;
+ALTER TABLE master_artist DROP FOREIGN KEY master_artist_artist_fk;
+ALTER TABLE release_track_artist DROP FOREIGN KEY release_track_artist__artist_fk;
+
+-- label_id foreign keys
+ALTER TABLE label_image DROP FOREIGN KEY label_image__label_fk;
+ALTER TABLE label_url DROP FOREIGN KEY label_url__label_fk;
+ALTER TABLE release_label DROP FOREIGN KEY release_label__label_fk;
+
+-- master_id foreign keys
+ALTER TABLE `release` DROP FOREIGN KEY release__master_fk;
+ALTER TABLE master_artist DROP FOREIGN KEY master_artist__master_fk;
+ALTER TABLE master_genre DROP FOREIGN KEY master_genre__master_fk;
+ALTER TABLE master_image DROP FOREIGN KEY master_image__master_fk;
+ALTER TABLE master_style DROP FOREIGN KEY master_style__master_fk;
+ALTER TABLE master_video DROP FOREIGN KEY master_video__master_fk;
+
+-- release_id foreign keys
+ALTER TABLE `master` DROP FOREIGN KEY master__main_release_fk;
+ALTER TABLE release_artist DROP FOREIGN KEY release_artist__release_fk;
+ALTER TABLE release_company DROP FOREIGN KEY release_company__release_fk;
+ALTER TABLE release_format DROP FOREIGN KEY release_format__release_fk;
+ALTER TABLE release_genre DROP FOREIGN KEY release_genre__release_fk;
+ALTER TABLE release_identifier DROP FOREIGN KEY release_identifier__release_fk;
+ALTER TABLE release_image DROP FOREIGN KEY release_image__release_fk;
+ALTER TABLE release_label DROP FOREIGN KEY release_label__release_fk;
+ALTER TABLE release_style DROP FOREIGN KEY release_style__release_fk;
+ALTER TABLE release_track DROP FOREIGN KEY release_track__release_fk;
+ALTER TABLE release_track_artist DROP FOREIGN KEY release_track_artist__release_fk;
+ALTER TABLE release_video DROP FOREIGN KEY release_video__release_fk;
+
+-- track_id foreign keys
+# ALTER TABLE release_track_artist DROP FOREIGN KEY release_track_artist__track_fk;


### PR DESCRIPTION
This PR adds a .sql file that contains all of the foreign key creation queries.  There is no integration for automatically kicking off these queries, since the creation of foreign keys take a long time and not every end user will find the value.  However, I figured this might be a worthy value-add for those who want to make the cleanest mysql database they can.