### PR TITLE
update data dump url

### DIFF
--- a/get_latest_dumps.sh
+++ b/get_latest_dumps.sh
@@ -3,8 +3,8 @@
 
 USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22"
 ACCEPT="Accept-Encoding: gzip, deflate"
-D_URL_LIST="http://discogs-data.s3-us-west-2.amazonaws.com/?delimiter=/&prefix=data/"$(date +"%Y")"/"
-D_URL_DIR="http://discogs-data.s3-us-west-2.amazonaws.com/data/"$(date +"%Y")"/"
+D_URL_LIST="http://discogs-data-dumps.s3-us-west-2.amazonaws.com/?delimiter=/&prefix=data/"$(date +"%Y")"/"
+D_URL_DIR="http://discogs-data-dumps.s3-us-west-2.amazonaws.com/data/"$(date +"%Y")"/"
 D_TMP=/tmp/discogs.urls
 D_PATTERN="discogs_[0-9]{8}_(artists|labels|masters|releases).xml.gz"
 


### PR DESCRIPTION
as pointed out in #138 the data url has been updated to discogs-data-**dumps**.s3-us-west-2, this PR fixes that