### PR TITLE
update ddl and dml files for postgres

### DIFF
--- a/postgresql/sql/DropFKConstraints.sql
+++ b/postgresql/sql/DropFKConstraints.sql
@@ -4,23 +4,21 @@ ALTER TABLE artist_namevariation DROP CONSTRAINT IF EXISTS artist_namevariation_
 ALTER TABLE artist_alias DROP CONSTRAINT IF EXISTS artist_alias_fk_artist;
 ALTER TABLE artist_alias DROP CONSTRAINT IF EXISTS artist_alias_fk_alias_artist;
 ALTER TABLE group_member DROP CONSTRAINT IF EXISTS group_member_fk_group;
-ALTER TABLE group_member DROP CONSTRAINT IF EXISTS group_member_fk_member;
 
 
 --- labels
 ALTER TABLE label DROP CONSTRAINT IF EXISTS label_fk_parent_label;
 ALTER TABLE label_url DROP CONSTRAINT IF EXISTS label_url_fk_label;
 
+
 --- masters
-ALTER TABLE master DROP CONSTRAINT IF EXISTS master_fk_main_release;
 ALTER TABLE master_artist DROP CONSTRAINT IF EXISTS master_artist_fk_master;
-ALTER TABLE master_artist DROP CONSTRAINT IF EXISTS master_artist_fk_artist;
 ALTER TABLE master_video DROP CONSTRAINT IF EXISTS master_video_fk_master;
 ALTER TABLE master_genre DROP CONSTRAINT IF EXISTS master_genre_fk_master;
 ALTER TABLE master_style DROP CONSTRAINT IF EXISTS master_style_fk_master;
 
+
 --- releases
-ALTER TABLE release DROP CONSTRAINT IF EXISTS release_fk_master;
 ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS release_artist_fk_release;
 ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS release_artist_fk_artist;
 ALTER TABLE release_label DROP CONSTRAINT IF EXISTS release_label_fk_release;

--- a/postgresql/sql/DropIndexes.sql
+++ b/postgresql/sql/DropIndexes.sql
@@ -6,6 +6,7 @@ DROP INDEX group_member_idx_group;
 DROP INDEX group_member_idx_member;
 
 --- labels
+DROP INDEX label_idx_parent_label;
 DROP INDEX label_url_idx_url;
 
 --- masters
@@ -16,6 +17,7 @@ DROP INDEX master_genre_idx_master;
 DROP INDEX master_style_idx_master;
 
 --- releases
+DROP INDEX release_idx_master;
 DROP INDEX release_artist_idx_release;
 DROP INDEX release_artist_idx_artist;
 DROP INDEX release_label_idx_release;
@@ -26,7 +28,9 @@ DROP INDEX release_format_idx_release;
 DROP INDEX release_track_idx_release;
 DROP INDEX release_track_idx_sequence;
 DROP INDEX release_track_idx_parent;
+DROP INDEX release_track_idx_title;
 DROP INDEX release_track_artist_idx_release;
+DROP INDEX release_track_artist_idx_track_id;
 DROP INDEX release_track_artist_idx_track_sequence;
 DROP INDEX release_track_artist_idx_artist;
 DROP INDEX release_identifier_idx_release;

--- a/postgresql/sql/DropPrimaryKeys.sql
+++ b/postgresql/sql/DropPrimaryKeys.sql
@@ -1,16 +1,27 @@
 --- artists
 ALTER TABLE artist DROP CONSTRAINT IF EXISTS artist_pkey;
+ALTER TABLE artist_url DROP CONSTRAINT IF EXISTS artist_url_pkey;
+ALTER TABLE artist_namevariation DROP CONSTRAINT IF EXISTS artist_namevariation_pkey;
 
 --- labels
 ALTER TABLE label DROP CONSTRAINT IF EXISTS label_pkey;
+ALTER TABLE label_url DROP CONSTRAINT IF EXISTS label_url_pkey;
 
 --- masters
 ALTER TABLE master DROP CONSTRAINT IF EXISTS master_pkey;
+ALTER TABLE master_artist DROP CONSTRAINT IF EXISTS master_artist_pkey;
+ALTER TABLE master_video DROP CONSTRAINT IF EXISTS master_video_pkey;
+ALTER TABLE master_genre DROP CONSTRAINT IF EXISTS master_genre_pkey;
+ALTER TABLE master_style DROP CONSTRAINT IF EXISTS master_style_pkey;
 
 --- releases
 ALTER TABLE release DROP CONSTRAINT IF EXISTS release_pkey;
-ALTER TABLE release_track DROP CONSTRAINT IF EXISTS release_track_pkey;
-ALTER TABLE release_track_artist DROP CONSTRAINT IF EXISTS release_track__artist_pkey;
-ALTER TABLE release_format DROP CONSTRAINT IF EXISTS release_format_pkey;
-ALTER TABLE release_label DROP CONSTRAINT IF EXISTS release_label_pkey;
 ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS release_artist_pkey;
+ALTER TABLE release_company DROP CONSTRAINT IF EXISTS release_company_pkey;
+ALTER TABLE release_format DROP CONSTRAINT IF EXISTS release_format_pkey;
+ALTER TABLE release_genre DROP CONSTRAINT IF EXISTS release_genre_pkey;
+ALTER TABLE release_identifier DROP CONSTRAINT IF EXISTS release_identifier_pkey;
+ALTER TABLE release_label DROP CONSTRAINT IF EXISTS release_label_pkey;
+ALTER TABLE release_track DROP CONSTRAINT IF EXISTS release_track_pkey;
+ALTER TABLE release_track_artist DROP CONSTRAINT IF EXISTS release_track_artist_pkey;
+ALTER TABLE release_video DROP CONSTRAINT IF EXISTS release_video_pkey;

--- a/postgresql/sql/DropTables.sql
+++ b/postgresql/sql/DropTables.sql
@@ -1,34 +1,34 @@
 --- artist
-DROP TABLE artist_url;
-DROP TABLE artist_namevariation;
-DROP TABLE artist_alias;
-DROP TABLE artist_image;
-DROP TABLE group_member;
-DROP TABLE artist;
+DROP TABLE IF EXISTS artist;
+DROP TABLE IF EXISTS artist_alias;
+DROP TABLE IF EXISTS artist_image;
+DROP TABLE IF EXISTS artist_namevariation;
+DROP TABLE IF EXISTS group_member;
+DROP TABLE IF EXISTS artist_url;
 
 --- labels
-DROP TABLE label_url;
-DROP TABLE label_image;
-DROP TABLE label;
+DROP TABLE IF EXISTS label;
+DROP TABLE IF EXISTS label_image;
+DROP TABLE IF EXISTS label_url;
 
 --- masters
-DROP TABLE master_artist;
-DROP TABLE master_video;
-DROP TABLE master_genre;
-DROP TABLE master_style;
-DROP TABLE master_image;
-DROP TABLE master;
+DROP TABLE IF EXISTS master;
+DROP TABLE IF EXISTS master_artist;
+DROP TABLE IF EXISTS master_genre;
+DROP TABLE IF EXISTS master_image;
+DROP TABLE IF EXISTS master_style;
+DROP TABLE IF EXISTS master_video;
 
 --- releases
-DROP TABLE release_artist;
-DROP TABLE release_label;
-DROP TABLE release_genre;
-DROP TABLE release_style;
-DROP TABLE release_format;
-DROP TABLE release_track;
-DROP TABLE release_track_artist;
-DROP TABLE release_identifier;
-DROP TABLE release_video;
-DROP TABLE release_company;
-DROP TABLE release_image;
-DROP TABLE release;
+DROP TABLE IF EXISTS release;
+DROP TABLE IF EXISTS release_artist;
+DROP TABLE IF EXISTS release_company;
+DROP TABLE IF EXISTS release_format;
+DROP TABLE IF EXISTS release_genre;
+DROP TABLE IF EXISTS release_identifier;
+DROP TABLE IF EXISTS release_image;
+DROP TABLE IF EXISTS release_label;
+DROP TABLE IF EXISTS release_style;
+DROP TABLE IF EXISTS release_track;
+DROP TABLE IF EXISTS release_track_artist;
+DROP TABLE IF EXISTS release_video;

--- a/postgresql/sql/TruncateTables.sql
+++ b/postgresql/sql/TruncateTables.sql
@@ -3,11 +3,13 @@ TRUNCATE TABLE artist;
 TRUNCATE TABLE artist_url;
 TRUNCATE TABLE artist_namevariation;
 TRUNCATE TABLE artist_alias;
+TRUNCATE TABLE artist_image;
 TRUNCATE TABLE group_member;
 
 --- labels
 TRUNCATE TABLE label;
 TRUNCATE TABLE label_url;
+TRUNCATE TABLE label_image;
 
 --- masters
 TRUNCATE TABLE master;
@@ -15,6 +17,7 @@ TRUNCATE TABLE master_artist;
 TRUNCATE TABLE master_video;
 TRUNCATE TABLE master_genre;
 TRUNCATE TABLE master_style;
+TRUNCATE TABLE master_image;
 
 --- releases
 TRUNCATE TABLE release;
@@ -28,3 +31,4 @@ TRUNCATE TABLE release_track_artist;
 TRUNCATE TABLE release_identifier;
 TRUNCATE TABLE release_video;
 TRUNCATE TABLE release_company;
+TRUNCATE TABLE release_image;


### PR DESCRIPTION
drop tables-add if exist for safer drops
make sure all create statements have corresponding drop statements

happy to hear your thoughts on this, this is only minimally tested but I noticed that running the `drop` script didn't drop everything so I went ahead and updated all the scripts